### PR TITLE
Add attributes overrides so windows works

### DIFF
--- a/cookbooks/hardening/recipes/default.rb
+++ b/cookbooks/hardening/recipes/default.rb
@@ -8,5 +8,8 @@ if node['os'] == 'linux'
   include_recipe 'os-hardening::default'
   include_recipe 'hardening::remediation'
 elsif node['os'] == 'windows'
+  node.default['security_policy']['rights']['SeNetworkLogonRight'] = nil
+  node.default['security_policy']['rights']['SeRemoteInteractiveLogonRight'] = nil
+  node.default['security_policy']['rights']['SeTrustedCredManAccessPrivilege'] = nil
   include_recipe 'windows-hardening'
 end


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

The Windows hardening cookbook locks down network access and a few other things that will break people being able to connect to their newly build Windows node during the module. This fixes that so that they can RDP or WinRM to the machine after being hardened.