### PR TITLE
CHEF-25316 - quick-archive - add_archive_note_to_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
+# Archived Repository
+
+This repository has been archived and will no longer receive updates. 
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).
+If you are a Chef customer and need support for this repository, please contact your Chef account team.
+
 # Overview
 This repo contains the base material for the 'Managing a Node With Policyfiles' Learn Chef Rally module.


### PR DESCRIPTION
This PR adds an archive notice to the top of the README.md to indicate that this repository is no longer maintained and has been archived as part of the Repository Standardization Initiative.